### PR TITLE
Add accessibility auscultation report builder

### DIFF
--- a/accessibility-auscultation.js
+++ b/accessibility-auscultation.js
@@ -1,0 +1,492 @@
+const DEFAULT_TAXONOMY = new Set([
+  'NAVIGATION',
+  'CLICK',
+  'SCROLL',
+  'SEARCH',
+  'PRODUCT_LIST',
+  'PRODUCT_DETAIL',
+  'ADD_TO_CART',
+  'CART_VIEW',
+  'CHECKOUT_START',
+  'PAYMENT',
+  'ORDER_CONFIRMATION',
+  'LOGIN/REGISTER',
+  'FILTER/SORT',
+  'FORM_ENTRY',
+  'UNKNOWN'
+]);
+
+function clamp(value, min = 0, max = 1) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function parseTimestamp(ts) {
+  if (!ts) {
+    return Date.now();
+  }
+  if (typeof ts === 'number') {
+    return ts;
+  }
+  const parsed = Date.parse(ts);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function extractPrimaryPackage(events) {
+  const counts = new Map();
+  events.forEach(event => {
+    const pkg = event?.data?.packageName || event?.packageName;
+    if (!pkg) return;
+    counts.set(pkg, (counts.get(pkg) || 0) + 1);
+  });
+  let primary = null;
+  let maxCount = 0;
+  for (const [pkg, count] of counts.entries()) {
+    if (count > maxCount) {
+      primary = pkg;
+      maxCount = count;
+    }
+  }
+  return { packageName: primary, count: maxCount };
+}
+
+function buildCapabilityMap(events) {
+  const capabilities = {
+    emits_clicks: false,
+    emits_scrolls: false,
+    exposes_ids: false,
+    text_richness: 'low',
+    structure: {
+      recyclerView: false,
+      tabs: false,
+      bottom_nav: false,
+      webview_ratio: 'unknown'
+    },
+    known_patterns: {
+      add_to_cart: new Set(),
+      cart: new Set(),
+      search: new Set()
+    }
+  };
+
+  let textSamples = 0;
+  let textLengthTotal = 0;
+  let webViewEvents = 0;
+
+  events.forEach(event => {
+    const type = event.eventType;
+    if (!capabilities.emits_clicks && type === 'VIEW_CLICKED') {
+      capabilities.emits_clicks = true;
+    }
+    if (!capabilities.emits_scrolls && (type === 'SCROLL' || type === 'VIEW_SCROLLED')) {
+      capabilities.emits_scrolls = true;
+    }
+
+    const element = event.data?.element || {};
+    if (!capabilities.exposes_ids && (element.id || element.viewIdResourceName)) {
+      capabilities.exposes_ids = true;
+    }
+
+    const className = element.className || '';
+    if (!capabilities.structure.recyclerView && /recyclerview/i.test(className)) {
+      capabilities.structure.recyclerView = true;
+    }
+    if (!capabilities.structure.tabs && /tab(layout|host|item)/i.test(className)) {
+      capabilities.structure.tabs = true;
+    }
+    if (!capabilities.structure.bottom_nav && /bottomnavigation/i.test(className)) {
+      capabilities.structure.bottom_nav = true;
+    }
+    if (/webview/i.test(className)) {
+      webViewEvents += 1;
+    }
+
+    const productInfo = event.data?.productInfo;
+    const textCandidates = [];
+    if (productInfo?.productName) {
+      textCandidates.push(productInfo.productName);
+    }
+    if (productInfo?.cartAction) {
+      textCandidates.push(productInfo.cartAction);
+    }
+    if (Array.isArray(productInfo?.allTexts)) {
+      textCandidates.push(...productInfo.allTexts);
+    }
+    if (element.text) {
+      textCandidates.push(element.text);
+    }
+    if (element.contentDescription) {
+      textCandidates.push(element.contentDescription);
+    }
+
+    textCandidates.forEach(text => {
+      if (!text) return;
+      textSamples += 1;
+      textLengthTotal += text.length;
+
+      const lower = text.toLowerCase();
+      if (/(ajouter|add).*(panier|cart)/i.test(text)) {
+        capabilities.known_patterns.add_to_cart.add(text.trim());
+      }
+      if (/panier|cart/i.test(text)) {
+        capabilities.known_patterns.cart.add(text.trim());
+      }
+      if (/recherche|search/i.test(text)) {
+        capabilities.known_patterns.search.add(text.trim());
+      }
+    });
+  });
+
+  if (textSamples > 0) {
+    const avg = textLengthTotal / textSamples;
+    capabilities.text_richness = avg > 60 ? 'high' : avg > 25 ? 'med' : 'low';
+  }
+
+  const totalEvents = events.length || 1;
+  const webRatio = webViewEvents / totalEvents;
+  if (webRatio > 0) {
+    capabilities.structure.webview_ratio = webRatio >= 0.5 ? 'high' : webRatio >= 0.2 ? 'medium' : 'low';
+  }
+
+  // Convert sets to arrays
+  capabilities.known_patterns.add_to_cart = Array.from(capabilities.known_patterns.add_to_cart);
+  capabilities.known_patterns.cart = Array.from(capabilities.known_patterns.cart);
+  capabilities.known_patterns.search = Array.from(capabilities.known_patterns.search);
+
+  return capabilities;
+}
+
+function getBounds(element) {
+  const bounds = element?.bounds || element?.boundsInScreen;
+  if (!bounds || typeof bounds !== 'object') {
+    return null;
+  }
+  const { left, top, right, bottom } = bounds;
+  if ([left, top, right, bottom].some(value => typeof value !== 'number')) {
+    return null;
+  }
+  return { l: left, t: top, r: right, b: bottom };
+}
+
+function buildWidget(element = {}) {
+  return {
+    class: element.className || null,
+    id: element.id || element.viewIdResourceName || null,
+    text: element.text || null,
+    desc: element.contentDescription || null
+  };
+}
+
+function inferCategory(event, widgetText, appConfig) {
+  const rawType = event.eventType;
+  const lowerText = (widgetText || '').toLowerCase();
+  const productInfo = event.data?.productInfo || {};
+  const price = productInfo.price || '';
+  const allTexts = (productInfo.allTexts || []).map(text => text.toLowerCase());
+  let category = 'UNKNOWN';
+  let confidence = 0.2;
+  const evidence = [];
+  let inferred = false;
+  let screenGuess = null;
+  const productGuess = {};
+
+  if (productInfo.productName) {
+    productGuess.title = productInfo.productName;
+  }
+  if (price) {
+    productGuess.price = price;
+  }
+
+  if (rawType === 'ADD_TO_CART' || /(ajouter|add).*(panier|cart)/i.test(widgetText || '') ||
+      allTexts.some(text => /(ajouter|add).*(panier|cart)/i.test(text))) {
+    category = 'ADD_TO_CART';
+    screenGuess = 'PRODUCT_DETAIL';
+    confidence += rawType === 'ADD_TO_CART' ? 0.5 : 0.35;
+    evidence.push('pattern:add_to_cart');
+    if (price) {
+      confidence += 0.1;
+      evidence.push('price_present');
+    }
+    if (rawType !== 'ADD_TO_CART') {
+      inferred = true;
+    }
+  } else if (rawType === 'VIEW_CLICKED' && /panier|cart/.test(lowerText)) {
+    category = 'CART_VIEW';
+    screenGuess = 'CART_VIEW';
+    confidence += 0.4;
+    evidence.push('text:panier');
+  } else if (rawType === 'VIEW_CLICKED' && /rechercher|search/.test(lowerText)) {
+    category = 'SEARCH';
+    screenGuess = 'SEARCH';
+    confidence += 0.4;
+    evidence.push('text:search');
+  } else if (rawType === 'VIEW_CLICKED') {
+    category = 'CLICK';
+    confidence += 0.25;
+    evidence.push('raw_event:VIEW_CLICKED');
+  } else if (rawType === 'SCROLL' || rawType === 'VIEW_SCROLLED') {
+    category = 'SCROLL';
+    confidence += 0.35;
+    evidence.push('raw_event:SCROLL');
+    if (allTexts.some(text => /€|eur|prix|kg/.test(text))) {
+      category = 'PRODUCT_LIST';
+      screenGuess = 'PRODUCT_LIST';
+      confidence += 0.15;
+      evidence.push('context:price_detected');
+    }
+  } else if (rawType === 'CONTENT_CHANGED' && allTexts.some(text => /panier|cart/.test(text))) {
+    category = 'CART_VIEW';
+    confidence += 0.3;
+    screenGuess = 'CART_VIEW';
+    evidence.push('content_change:cart_text');
+  } else if (rawType === 'VIEW_TEXT_CHANGED') {
+    category = 'FORM_ENTRY';
+    confidence += 0.25;
+    evidence.push('raw_event:VIEW_TEXT_CHANGED');
+  } else if (rawType === 'WINDOW_STATE_CHANGED') {
+    category = 'NAVIGATION';
+    confidence += 0.25;
+    evidence.push('raw_event:WINDOW_STATE_CHANGED');
+  }
+
+  if (category === 'ADD_TO_CART' && appConfig?.buttonPatterns?.addToCart) {
+    const match = appConfig.buttonPatterns.addToCart.some(pattern => lowerText.includes(pattern.toLowerCase()));
+    if (match) {
+      confidence += 0.1;
+      evidence.push('app_pattern:add_to_cart');
+    }
+  }
+
+  confidence = clamp(confidence);
+
+  return {
+    category,
+    confidence,
+    evidence,
+    inferred,
+    screenGuess,
+    productGuess: Object.keys(productGuess).length > 0 ? productGuess : null
+  };
+}
+
+function normalizeEvents(events, appConfig) {
+  return events.map(event => {
+    const element = event.data?.element || {};
+    const productInfo = event.data?.productInfo || {};
+    const widgetText = element.text || productInfo.productName || productInfo.cartAction || '';
+    const { category, confidence, evidence, inferred, screenGuess, productGuess } = inferCategory(event, widgetText, appConfig);
+    const bounds = getBounds(element);
+    let approx = null;
+    if (bounds) {
+      approx = {
+        cx: Math.round((bounds.l + bounds.r) / 2),
+        cy: Math.round((bounds.t + bounds.b) / 2)
+      };
+    }
+
+    return {
+      ts: parseTimestamp(event.timestamp),
+      package: event.data?.packageName || event.packageName || null,
+      activity: event.data?.activity || event.data?.windowStateChange || null,
+      raw_type: event.eventType,
+      category,
+      widget: buildWidget(element),
+      bounds: bounds,
+      approx_xy: approx,
+      context: {
+        screen_guess: screenGuess,
+        product_guess: productGuess,
+        container: event.data?.scrollInfo?.context || event.data?.element?.container || null
+      },
+      confidence,
+      evidence,
+      inferred,
+      raw: event
+    };
+  });
+}
+
+function buildTimeline(normalizedEvents) {
+  const timeline = [];
+  let lastCategory = null;
+  normalizedEvents.forEach(ev => {
+    if (ev.category === 'UNKNOWN') {
+      return;
+    }
+    if (ev.category === lastCategory) {
+      return;
+    }
+    lastCategory = ev.category;
+    timeline.push({
+      ts: new Date(ev.ts).toISOString(),
+      category: ev.category,
+      label: ev.widget.text || ev.raw?.data?.productInfo?.productName || ev.raw?.eventType || ev.category,
+      confidence: ev.confidence
+    });
+  });
+  return timeline;
+}
+
+function summarizeCategories(normalizedEvents) {
+  const summary = new Map();
+  normalizedEvents.forEach(ev => {
+    const entry = summary.get(ev.category) || { count: 0, examples: [] };
+    entry.count += 1;
+    if (entry.examples.length < 3 && (ev.widget.text || ev.raw?.data?.productInfo?.productName)) {
+      entry.examples.push(ev.widget.text || ev.raw?.data?.productInfo?.productName);
+    }
+    summary.set(ev.category, entry);
+  });
+  return Array.from(summary.entries()).map(([category, data]) => ({
+    category,
+    count: data.count,
+    examples: data.examples
+  })).sort((a, b) => b.count - a.count);
+}
+
+function buildConfidenceReport(normalizedEvents) {
+  const strong = [];
+  const medium = [];
+  const weak = [];
+
+  normalizedEvents.forEach(ev => {
+    const description = `${ev.category} → ${ev.widget.text || ev.raw_type}`;
+    if (ev.confidence >= 0.8) {
+      strong.push(description);
+    } else if (ev.confidence >= 0.5) {
+      medium.push(description);
+    } else if (ev.confidence >= 0.3) {
+      weak.push(description);
+    }
+  });
+
+  const observedCategories = new Set(normalizedEvents.map(ev => ev.category));
+  const missing = Array.from(DEFAULT_TAXONOMY).filter(cat => !observedCategories.has(cat) && cat !== 'UNKNOWN');
+
+  return {
+    strong,
+    medium,
+    weak,
+    missing
+  };
+}
+
+function buildInferences(normalizedEvents) {
+  return normalizedEvents
+    .filter(ev => ev.inferred && ev.category !== 'UNKNOWN')
+    .map(ev => ({
+      hypothesis: ev.category,
+      because: ev.evidence,
+      confidence: ev.confidence,
+      text: ev.widget.text || ev.raw?.data?.productInfo?.productName || ev.raw_type,
+      timestamp: new Date(ev.ts).toISOString()
+    }));
+}
+
+function buildSummary(profile, timeline, categories, capabilityMap, reportStats) {
+  const lines = [];
+  lines.push(`- **App détectée** : ${profile.likely_brand || 'Inconnue'} (${profile.package || 'n/a'}).`);
+  lines.push(`- **Fenêtre analysée** : ${reportStats.durationSeconds}s (${profile.first_seen} → ${profile.last_seen}).`);
+  lines.push(`- **Événements** : ${reportStats.totalEvents} bruts, ${reportStats.knownCategories} catégorisés.`);
+  lines.push(`- **Capacités** : clics ${capabilityMap.emits_clicks ? '✔️' : '❌'}, scroll ${capabilityMap.emits_scrolls ? '✔️' : '❌'}, IDs ${capabilityMap.exposes_ids ? '✔️' : '❌'} (texte ${capabilityMap.text_richness}).`);
+  if (timeline.length > 0) {
+    lines.push(`- **Timeline** : ${timeline.map(step => `${step.category}`).join(' → ')}.`);
+  }
+  const addToCartCount = categories.find(cat => cat.category === 'ADD_TO_CART')?.count || 0;
+  lines.push(`- **Add-to-cart détectés** : ${addToCartCount} (confiance ${addToCartCount > 0 ? 'élevée' : 'nulle'}).`);
+  lines.push(`- **Forces** : ${reportStats.strongSignals.length > 0 ? reportStats.strongSignals.join(', ') : 'aucun signal fort identifié.'}`);
+  if (reportStats.missingSignals.length > 0) {
+    lines.push(`- **Manques** : ${reportStats.missingSignals.join(', ')}.`);
+  }
+  lines.push(`- **Prochaines étapes** : ${reportStats.nextSteps.join('; ')}.`);
+  return lines.join('\n');
+}
+
+function generateAuscultationReport(events, { appConfigManager } = {}) {
+  if (!Array.isArray(events) || events.length === 0) {
+    return {
+      app_profile: {
+        package: null,
+        likely_brand: null,
+        first_seen: null,
+        last_seen: null,
+        event_count: 0
+      },
+      capability_map: buildCapabilityMap([]),
+      session_timeline: [],
+      categorized_events: [],
+      inferences: [],
+      confidence_report: {
+        strong: [],
+        medium: [],
+        weak: [],
+        missing: Array.from(DEFAULT_TAXONOMY).filter(cat => cat !== 'UNKNOWN')
+      },
+      open_questions: ['Capturer une session avec des événements Android Accessibility pour générer le rapport.'],
+      summary_md: '- Aucun événement Accessibility fourni. Générer une capture avant de relancer l\'auscultation.'
+    };
+  }
+
+  const sortedEvents = [...events].sort((a, b) => parseTimestamp(a.timestamp) - parseTimestamp(b.timestamp));
+  const { packageName } = extractPrimaryPackage(sortedEvents);
+  const firstTs = parseTimestamp(sortedEvents[0].timestamp);
+  const lastTs = parseTimestamp(sortedEvents[sortedEvents.length - 1].timestamp);
+  const durationSeconds = Math.max(1, Math.round((lastTs - firstTs) / 1000));
+
+  let appMatch = null;
+  if (packageName && appConfigManager?.findAppByPackage) {
+    appMatch = appConfigManager.findAppByPackage(packageName);
+  }
+
+  const appProfile = {
+    package: packageName || null,
+    likely_brand: appMatch?.config?.name || sortedEvents[0]?.data?.app || null,
+    first_seen: new Date(firstTs).toISOString(),
+    last_seen: new Date(lastTs).toISOString(),
+    event_count: sortedEvents.length
+  };
+
+  const capabilityMap = buildCapabilityMap(sortedEvents);
+  const normalizedEvents = normalizeEvents(sortedEvents, appMatch?.config);
+  const timeline = buildTimeline(normalizedEvents);
+  const categories = summarizeCategories(normalizedEvents);
+  const inferences = buildInferences(normalizedEvents);
+  const confidenceReport = buildConfidenceReport(normalizedEvents);
+
+  const strongSignals = confidenceReport.strong.slice(0, 3);
+  const missingSignals = confidenceReport.missing.slice(0, 3).map(cat => `Pas de ${cat.toLowerCase()}`);
+  const nextSteps = [];
+  if (confidenceReport.missing.includes('CHECKOUT_START')) {
+    nextSteps.push('Déclencher un début de checkout pour observer la transition');
+  }
+  if (confidenceReport.missing.includes('PAYMENT')) {
+    nextSteps.push('Enregistrer un écran de paiement pour capturer les champs carte');
+  }
+  if (nextSteps.length === 0) {
+    nextSteps.push('Approfondir les parcours panier et commande');
+  }
+
+  const summary_md = buildSummary(appProfile, timeline, categories, capabilityMap, {
+    durationSeconds,
+    totalEvents: sortedEvents.length,
+    knownCategories: categories.filter(cat => cat.category !== 'UNKNOWN').length,
+    strongSignals,
+    missingSignals,
+    nextSteps
+  });
+
+  return {
+    app_profile: appProfile,
+    capability_map: capabilityMap,
+    session_timeline: timeline,
+    categorized_events: categories,
+    inferences,
+    confidence_report: confidenceReport,
+    open_questions: nextSteps,
+    summary_md,
+    normalized_events: normalizedEvents.map(({ raw, ...rest }) => rest)
+  };
+}
+
+module.exports = {
+  generateAuscultationReport
+};

--- a/app-config-manager.js
+++ b/app-config-manager.js
@@ -79,6 +79,23 @@ class AppConfigManager {
   }
 
   /**
+   * Recherche une app depuis son package sans modifier l'état courant
+   */
+  findAppByPackage(packageName) {
+    if (!packageName || !this.config?.apps) {
+      return null;
+    }
+
+    for (const [key, app] of Object.entries(this.config.apps)) {
+      if (app.packageName === packageName) {
+        return { key, config: app };
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Liste toutes les apps disponibles
    */
   listApps() {

--- a/public/accessibility-auscultation.html
+++ b/public/accessibility-auscultation.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>🧠 Prompt Auscultation - Accessibility</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            color: #1f2933;
+        }
+
+        .header {
+            background: rgba(255, 255, 255, 0.15);
+            backdrop-filter: blur(12px);
+            color: #fff;
+            padding: 32px 24px;
+            text-align: center;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+        }
+
+        .header h1 {
+            margin: 0;
+            font-size: 2rem;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .header p {
+            margin-top: 12px;
+            font-size: 1rem;
+            opacity: 0.85;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 32px 20px 64px;
+        }
+
+        .card {
+            background: #ffffff;
+            border-radius: 18px;
+            padding: 24px;
+            box-shadow: 0 20px 45px rgba(102, 126, 234, 0.25);
+            margin-bottom: 24px;
+        }
+
+        .controls {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 16px;
+            margin-bottom: 16px;
+        }
+
+        label {
+            font-weight: 600;
+            color: #4a5568;
+            display: block;
+            margin-bottom: 6px;
+        }
+
+        select, button {
+            width: 100%;
+            padding: 12px 14px;
+            border-radius: 10px;
+            border: 2px solid rgba(102, 126, 234, 0.25);
+            font-size: 1rem;
+        }
+
+        select {
+            background: #f8f9ff;
+        }
+
+        button {
+            background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            border: none;
+        }
+
+        button:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 25px rgba(32, 201, 151, 0.35);
+        }
+
+        button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+
+        .output-grid {
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: 20px;
+        }
+
+        .summary-box {
+            background: #f8f9ff;
+            border-radius: 14px;
+            padding: 20px;
+            border: 1px solid rgba(102, 126, 234, 0.2);
+            line-height: 1.6;
+            font-size: 0.95rem;
+        }
+
+        .summary-box strong {
+            color: #3730a3;
+        }
+
+        .json-box {
+            background: #111827;
+            color: #f9fafb;
+            border-radius: 14px;
+            padding: 20px;
+            font-family: 'Fira Code', 'Courier New', monospace;
+            font-size: 0.85rem;
+            line-height: 1.5;
+            overflow-x: auto;
+            max-height: 420px;
+        }
+
+        .status-bar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 12px;
+        }
+
+        .status-label {
+            font-weight: 600;
+            color: #4a5568;
+        }
+
+        .status-value {
+            font-family: 'Fira Code', monospace;
+            background: rgba(102, 126, 234, 0.12);
+            padding: 6px 10px;
+            border-radius: 6px;
+        }
+
+        .timeline {
+            margin-top: 16px;
+            border-left: 3px solid rgba(102, 126, 234, 0.4);
+            padding-left: 16px;
+        }
+
+        .timeline-item {
+            margin-bottom: 12px;
+        }
+
+        .timeline-item h4 {
+            margin: 0;
+            font-size: 0.95rem;
+            color: #4338ca;
+        }
+
+        .timeline-item small {
+            color: #718096;
+            font-family: 'Fira Code', monospace;
+        }
+
+        .inline-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-top: 12px;
+        }
+
+        .inline-actions button.secondary {
+            background: linear-gradient(135deg, #6c757d 0%, #495057 100%);
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #0f172a;
+                color: #e2e8f0;
+            }
+            .card {
+                background: rgba(15, 23, 42, 0.85);
+                backdrop-filter: blur(18px);
+                color: inherit;
+                box-shadow: 0 20px 45px rgba(15, 23, 42, 0.8);
+            }
+            label {
+                color: #e2e8f0;
+            }
+            select {
+                background: rgba(30, 41, 59, 0.9);
+                color: inherit;
+                border-color: rgba(99, 102, 241, 0.35);
+            }
+            .summary-box {
+                background: rgba(30, 41, 59, 0.8);
+                border-color: rgba(99, 102, 241, 0.25);
+            }
+            .json-box {
+                background: rgba(17, 24, 39, 0.85);
+            }
+            .status-value {
+                background: rgba(99, 102, 241, 0.18);
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🧠 Prompt Auscultation <span style="font-size:1rem;">(Accessibility)</span></h1>
+        <p>Génère un résumé structuré et un JSON conforme au prompt « Auscultation d’app via Accessibility » à partir des événements capturés.</p>
+    </div>
+
+    <div class="container">
+        <div class="card">
+            <div class="controls">
+                <div>
+                    <label for="appSelect">Application</label>
+                    <select id="appSelect"></select>
+                </div>
+                <div>
+                    <label for="platformSelect">Plateforme</label>
+                    <select id="platformSelect">
+                        <option value="">Toutes</option>
+                        <option value="android_native" selected>Android Accessibility</option>
+                        <option value="web">Web</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="sessionInput">Session ID (optionnel)</label>
+                    <input type="text" id="sessionInput" placeholder="session_..." style="width:100%;padding:12px 14px;border-radius:10px;border:2px solid rgba(102,126,234,0.25);" />
+                </div>
+                <div style="align-self:end;">
+                    <button id="generateBtn">🚀 Générer le rapport</button>
+                </div>
+            </div>
+            <div class="inline-actions">
+                <button class="secondary" id="copyPromptBtn" disabled>📋 Copier le prompt complet</button>
+                <button class="secondary" id="refreshBtn">🔄 Rafraîchir la liste des apps</button>
+            </div>
+        </div>
+
+        <div class="card" id="statusCard">
+            <div class="status-bar">
+                <div>
+                    <span class="status-label">Événements traités :</span>
+                    <span class="status-value" id="eventCount">0</span>
+                </div>
+                <div>
+                    <span class="status-label">Fenêtre :</span>
+                    <span class="status-value" id="durationWindow">-</span>
+                </div>
+                <div>
+                    <span class="status-label">Package :</span>
+                    <span class="status-value" id="packageLabel">-</span>
+                </div>
+            </div>
+            <div class="timeline" id="timeline"></div>
+        </div>
+
+        <div class="output-grid">
+            <div class="card">
+                <h2 style="margin-top:0;">Résumé Markdown</h2>
+                <div class="summary-box" id="summaryBox">Aucun rapport généré pour le moment.</div>
+            </div>
+            <div class="card">
+                <h2 style="margin-top:0;">Payload JSON</h2>
+                <pre class="json-box" id="jsonBox">{\n  "message": "Clique sur \"Générer le rapport\" pour obtenir le JSON."\n}</pre>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const appSelect = document.getElementById('appSelect');
+        const platformSelect = document.getElementById('platformSelect');
+        const sessionInput = document.getElementById('sessionInput');
+        const generateBtn = document.getElementById('generateBtn');
+        const copyBtn = document.getElementById('copyPromptBtn');
+        const refreshBtn = document.getElementById('refreshBtn');
+        const summaryBox = document.getElementById('summaryBox');
+        const jsonBox = document.getElementById('jsonBox');
+        const eventCountEl = document.getElementById('eventCount');
+        const durationWindowEl = document.getElementById('durationWindow');
+        const packageLabelEl = document.getElementById('packageLabel');
+        const timelineEl = document.getElementById('timeline');
+
+        let lastReport = null;
+        let appsCache = [];
+
+        function escapeHtml(text) {
+            return text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+        }
+
+        function markdownToHtml(markdown) {
+            if (!markdown) return '<em>Aucun contenu.</em>';
+            const lines = markdown.split(/\n+/).filter(Boolean);
+            const items = lines.map(line => {
+                const clean = line.replace(/^[-*]\s*/, '').trim();
+                let html = escapeHtml(clean);
+                html = html.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+                html = html.replace(/\*(.*?)\*/g, '<em>$1</em>');
+                return `<li>${html}</li>`;
+            });
+            return `<ul>${items.join('')}</ul>`;
+        }
+
+        async function loadApps() {
+            try {
+                const response = await fetch('/api/apps');
+                const data = await response.json();
+                if (!data.success) throw new Error(data.error || 'Réponse invalide');
+
+                appsCache = data.apps || [];
+                appSelect.innerHTML = '';
+
+                if (appsCache.length === 0) {
+                    const option = document.createElement('option');
+                    option.value = '';
+                    option.textContent = 'Aucune app configurée';
+                    appSelect.appendChild(option);
+                    generateBtn.disabled = true;
+                    return;
+                }
+
+                appsCache.forEach(app => {
+                    const option = document.createElement('option');
+                    option.value = app.packageName;
+                    option.textContent = `${app.name} (${app.key})`;
+                    if (app.packageName === 'com.carrefour.fid.android') {
+                        option.selected = true;
+                    }
+                    appSelect.appendChild(option);
+                });
+
+                generateBtn.disabled = false;
+            } catch (error) {
+                console.error('Erreur chargement apps', error);
+                appSelect.innerHTML = '<option value="">Erreur de chargement</option>';
+                generateBtn.disabled = true;
+            }
+        }
+
+        function updateTimeline(timeline = []) {
+            if (!timeline.length) {
+                timelineEl.innerHTML = '<p style="color:#6b7280;font-style:italic;">Aucun événement qualifié pour la timeline.</p>';
+                return;
+            }
+
+            const items = timeline.map(item => `
+                <div class="timeline-item">
+                    <h4>${escapeHtml(item.category)}</h4>
+                    <div>${escapeHtml(item.label || '')}</div>
+                    <small>${escapeHtml(item.ts)} · confiance ${(item.confidence * 100).toFixed(0)}%</small>
+                </div>
+            `);
+            timelineEl.innerHTML = items.join('');
+        }
+
+        function updateStatus(report, meta) {
+            eventCountEl.textContent = meta.event_count || 0;
+            durationWindowEl.textContent = report?.app_profile?.first_seen && report?.app_profile?.last_seen
+                ? `${report.app_profile.first_seen} → ${report.app_profile.last_seen}`
+                : '-';
+            packageLabelEl.textContent = report?.app_profile?.package || 'n/a';
+        }
+
+        function enableCopy(report) {
+            copyBtn.disabled = !report;
+        }
+
+        function buildPromptPayload(report) {
+            if (!report) return '';
+            return `${report.summary_md}\n\nJSON:\n${JSON.stringify(report, null, 2)}`;
+        }
+
+        async function generateReport() {
+            const pkg = appSelect.value;
+            const platform = platformSelect.value;
+            const sessionId = sessionInput.value.trim();
+
+            const params = new URLSearchParams();
+            if (pkg) params.set('package', pkg);
+            if (platform) params.set('platform', platform);
+            if (sessionId) params.set('sessionId', sessionId);
+
+            generateBtn.disabled = true;
+            generateBtn.textContent = '⏳ Génération en cours...';
+            summaryBox.innerHTML = '<em>Génération du rapport en cours...</em>';
+            jsonBox.textContent = '...';
+            updateTimeline([]);
+
+            try {
+                const response = await fetch(`/api/auscultation-report?${params.toString()}`);
+                const data = await response.json();
+
+                if (!data.success) {
+                    throw new Error(data.error || 'Erreur serveur');
+                }
+
+                lastReport = data.report;
+                summaryBox.innerHTML = markdownToHtml(lastReport.summary_md);
+                jsonBox.textContent = JSON.stringify(lastReport, null, 2);
+                updateTimeline(lastReport.session_timeline);
+                updateStatus(lastReport, data);
+                enableCopy(lastReport);
+            } catch (error) {
+                console.error('Erreur génération rapport', error);
+                summaryBox.innerHTML = `<strong style="color:#dc2626;">Erreur:</strong> ${escapeHtml(error.message)}`;
+                jsonBox.textContent = JSON.stringify({ error: error.message }, null, 2);
+                lastReport = null;
+                updateTimeline([]);
+                enableCopy(null);
+            } finally {
+                generateBtn.disabled = false;
+                generateBtn.textContent = '🚀 Générer le rapport';
+            }
+        }
+
+        copyBtn.addEventListener('click', async () => {
+            if (!lastReport) return;
+            try {
+                await navigator.clipboard.writeText(buildPromptPayload(lastReport));
+                copyBtn.textContent = '✅ Copié !';
+                setTimeout(() => (copyBtn.textContent = '📋 Copier le prompt complet'), 1500);
+            } catch (error) {
+                console.error('Erreur copie prompt', error);
+                copyBtn.textContent = '⚠️ Impossible de copier';
+                setTimeout(() => (copyBtn.textContent = '📋 Copier le prompt complet'), 2000);
+            }
+        });
+
+        refreshBtn.addEventListener('click', () => {
+            refreshBtn.disabled = true;
+            refreshBtn.textContent = '⏳ Rafraîchissement...';
+            loadApps().finally(() => {
+                refreshBtn.disabled = false;
+                refreshBtn.textContent = '🔄 Rafraîchir la liste des apps';
+            });
+        });
+
+        generateBtn.addEventListener('click', generateReport);
+
+        loadApps();
+    </script>
+</body>
+</html>

--- a/public/carrefour-dashboard.html
+++ b/public/carrefour-dashboard.html
@@ -419,6 +419,7 @@
                     <div class="toggle-slider"></div>
                 </div>
             </div>
+            <button class="btn" onclick="window.open('/accessibility-auscultation', '_blank')">🧠 Prompt Auscultation</button>
             <button class="btn" onclick="showLastPage()">📄 Dernière page</button>
             <button class="btn" onclick="clearPages()">🗑️ Effacer</button>
             <button class="btn" onclick="refreshData()">🔄 Actualiser</button>


### PR DESCRIPTION
## Summary
- add an accessibility auscultation report generator that normalizes events and builds prompt-ready data
- expose the auscultation report API, serve a dedicated UI, and link it from the Carrefour dashboard
- extend the app config manager with a package lookup helper used by the new report

## Testing
- node - <<'NODE'\nconst fs = require('fs');\nconst path = require('path');\nconst AppConfigManager = require('./app-config-manager');\nconst { generateAuscultationReport } = require('./accessibility-auscultation');\n\nconst filePath = path.join(__dirname, 'temp-tracking-latest.json');\nconst raw = fs.readFileSync(filePath, 'utf8').replace(/^\\uFEFF/, '');\nconst data = JSON.parse(raw).value || [];\nconst manager = new AppConfigManager('./app-configs.json');\nconst report = generateAuscultationReport(data, { appConfigManager: manager });\nconsole.log('Summary:');\nconsole.log(report.summary_md);\nconsole.log('\nCategories:', report.categorized_events.slice(0,3));\nNODE

------
https://chatgpt.com/codex/tasks/task_e_68e0c5b97d708329b21f5a47529a7ce0